### PR TITLE
Add basic package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Simple Node.js script to fetch raw images from MSL/Curiosity on a particular sol
 * cheerio
 * image-size
 
+Just run `npm install` to download and install these.
+
 ## Running
 `node fetchcuriosity.js <sol> <instrument>`
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name" : "fetchspacecraftraw",
+  "version" : "0.0.1",
+  "description" : "A collection of scripts to download images from spacecraft raw image sites.",
+  "repository" :
+    { "type" : "git"
+    , "url" : "https://github.com/kmgill/fetchcuriositysol"
+    },
+  "dependencies" :
+    { "cheerio" : ">=0.19.0"
+    , "image-size" : ">=0.3.5"
+    }
+}


### PR DESCRIPTION
Hi, thanks ofr posting your scripts. I saw them in your response to Emily Lakdawalla's tweet.

This adds a basic package description so the traditional `npm install` works to grab the dependencies. Makes it easier to get started.

I didn't try to do anything about imagemagick though.
