### PR TITLE
Make images directory if it doesn't exist.

### DIFF
--- a/fetchcassiniraw.js
+++ b/fetchcassiniraw.js
@@ -79,6 +79,12 @@ function fetchPage(page, query) {
 			}
 		}).get();
 		
+                var prefix = "images";
+                shared.createIfNotExists(prefix);
+                prefix += "/cassini";
+                shared.createIfNotExists(prefix);
+                prefix += "/";
+
 		for (var i = 0; i < links.length; i++) {
 			fetchThumbnailPage(host, links[i], function(imageUri, props) {
 				fetchImage(host, imageUri, props, function(data, props) {
@@ -95,9 +101,10 @@ function fetchPage(page, query) {
 					props.fileName = saveTo;
 					
 					var dir = (props.camera == "N") ? "NAC" : "WAC";
+                                        shared.createIfNotExists(prefix + dir);
 					
-					if (!fs.existsSync("images/cassini/" + dir + "/" + saveTo)) {
-						fs.writeFile("images/cassini/" + dir + "/" + saveTo, data, function(err) {
+					if (!fs.existsSync(prefix + dir + "/" + saveTo)) {
+						fs.writeFile(prefix + dir + "/" + saveTo, data, function(err) {
 							if(err) {
 								return console.log(err);
 							}

--- a/fetchcuriositysol.js
+++ b/fetchcuriositysol.js
@@ -105,12 +105,6 @@ function getCameraById(id) {
 	return null;
 }
 
-function createIfNotExists(path) {
-	if (!fs.existsSync(path)) {
-		fs.mkdirSync(path);
-	}
-}
-
 var handleImageData = function(image) {
 		
 	var host = image.url.match(/http:\/\/[\w.]+[^\/]/)[0].replace(/http:\/\//, "");
@@ -122,16 +116,16 @@ var handleImageData = function(image) {
 		image.type = size.type;
 		
 		var localFile = "images";
-		createIfNotExists(localFile);
+		shared.createIfNotExists(localFile);
 		
 		localFile += "/msl";
-		createIfNotExists(localFile);
+		shared.createIfNotExists(localFile);
 		
 		localFile += "/" + image.sol;
-		createIfNotExists(localFile);
+		shared.createIfNotExists(localFile);
 		
 		localFile += "/" + image.camera.id;
-		createIfNotExists(localFile);
+		shared.createIfNotExists(localFile);
 		
 		localFile += "/" + image.file;
 		

--- a/fetchnewhorizonsraw.js
+++ b/fetchnewhorizonsraw.js
@@ -154,7 +154,13 @@ function jpegUriToLevel1JpegUri(jpegUri) {
 }
 
 function saveData(data, path) {
-	fs.writeFile("images/newhorizons/" + path, data, function(err) {
+        var prefix = "images";
+        shared.createIfNotExists(prefix);
+        prefix += "/newhorizons";
+        shared.createIfNotExists("images/newhorizons");
+        prefix += "/"
+
+	fs.writeFile(prefix + path, data, function(err) {
 		if(err) {
 			return console.log(err);
 		}

--- a/shared.js
+++ b/shared.js
@@ -60,8 +60,16 @@ var getURL = function(host, uri, onsuccess, onfailure) {
 	req.end();
 
 }
+
+var createIfNotExists = function(path) {
+        if (!fs.existsSync(path)) {
+                fs.mkdirSync(path);
+        }
+}
+
 	
 
 
 exports.getImage = getImage;
 exports.getURL = getURL;
+exports.createIfNotExists = createIfNotExists;


### PR DESCRIPTION
Similarly, this allows all three scripts to succeed if run in a fresh directory.

Move createIfNotExists() from fetchcuriositysol.js into shared.js
and call if from fetchcassiniraw.js and fetchnewhorizonsraw.js.
